### PR TITLE
feat: sign-based role for calc and calc_exp macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,32 @@ the results are being returned as `BigDecimal`s with scale 2.
 I plan to provide ways to customize that, but I haven't had the time yet.
 PRs are welcome.
 
+### Sign-based role
+
+Starting from version `2.4.1`, you can style the rendered result based on the sign of the
+calculation by providing the [role](https://docs.asciidoctor.org/asciidoc/latest/attributes/roles/)
+to apply for each case. The role names are entirely up to you (they map to your document's roles /
+your PDF theme); the macro is agnostic to them:
+
+| Attribute       | Applied when the result is |
+|-----------------|----------------------------|
+| `role_positive` | greater than zero          |
+| `role_negative` | less than zero             |
+| `role_zero`     | equal to zero              |
+
+```asciidoc
+// renders 150.00 with the `success-bg` role applied
+calc:sum[100, 50, role_positive=success-bg, role_negative=danger-bg]
+
+// renders -50.00 with the `danger-bg` role applied
+calc:sub[50, 100, role_positive=success-bg, role_negative=danger-bg]
+```
+
+Each attribute is optional and independent: when the attribute matching the result's sign is not
+provided (or is left blank), no role is applied. This lets you, for instance, highlight only
+negative results by providing `role_negative` alone. Likewise, no role is applied when the result
+is not a valid number (for example, a `NaN` result).
+
 ### Invalid arguments
 
 If the `calc` macro isn't provided with a valid operation, that's it,
@@ -378,6 +404,19 @@ calc_exp:[exp=0.471 + 0.49, author=Johnny, calc_exp_license_type=non_commercial,
 
 For more info about how to use the rounding_mode attribute, see section
 [`Rounding in calc`](README.md#rounding-in-calc). The usage is the same as in this macro.
+
+### Sign-based role in calc_exp
+
+Similar to `calc`, starting from version `2.4.1`, you can style the rendered result based on its
+sign by setting the `role_positive`, `role_negative`, and `role_zero` attributes, for example:
+
+```asciidoc
+// renders the result with `success-bg` when positive, or `danger-bg` when negative
+calc_exp:[exp=3 - 9, author=Johnny, calc_exp_license_type=non_commercial, role_positive=success-bg, role_negative=danger-bg]
+```
+
+For more info about how these attributes work, see section
+[`Sign-based role`](README.md#sign-based-role). The usage is the same as in this macro.
 
 ### Invalid values
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.lealceldeiro</groupId>
   <artifactId>asciidoc-extensions</artifactId>
-  <version>2.4.0</version>
+  <version>2.4.1</version>
   <packaging>jar</packaging>
 
   <name>asciidoc-extensions</name>

--- a/src/main/java/com/lealceldeiro/asciidoc/extensions/Macro.java
+++ b/src/main/java/com/lealceldeiro/asciidoc/extensions/Macro.java
@@ -20,6 +20,13 @@ public final class Macro {
     public static final String LICENSE_TYPE = "calc_exp_license_type";
 
     public static final String ROUNDING_MODE = "rounding_mode";
+
+    /** Role applied to the rendered result when it is greater than zero. */
+    public static final String ROLE_POSITIVE = "role_positive";
+    /** Role applied to the rendered result when it is less than zero. */
+    public static final String ROLE_NEGATIVE = "role_negative";
+    /** Role applied to the rendered result when it equals zero. */
+    public static final String ROLE_ZERO = "role_zero";
   }
 
   public static final class Value {

--- a/src/main/java/com/lealceldeiro/asciidoc/extensions/Util.java
+++ b/src/main/java/com/lealceldeiro/asciidoc/extensions/Util.java
@@ -2,11 +2,53 @@ package com.lealceldeiro.asciidoc.extensions;
 
 import com.lealceldeiro.asciidoc.extensions.calclogger.ExtensionLogger;
 import com.lealceldeiro.asciidoc.extensions.calclogger.ExtensionLoggerFactory;
+import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Collections;
 import java.util.Map;
 
 public final class Util {
   private static final ExtensionLogger logger = ExtensionLoggerFactory.getInstance();
+
+  private Util() {
+  }
+
+  /**
+   * Resolves the phrase-node attributes that carry the role to apply to a calculated result,
+   * based on the sign of that result.
+   *
+   * <p>The role names themselves are supplied by the caller (they are opaque to this method):
+   * {@link Macro.Key#ROLE_POSITIVE} when the result is greater than zero,
+   * {@link Macro.Key#ROLE_NEGATIVE} when it is less than zero, and
+   * {@link Macro.Key#ROLE_ZERO} when it equals zero. When the relevant role is not provided
+   * (or is blank), or when {@code result} is not a number, no role is applied.</p>
+   *
+   * @param result          the calculated result, as produced by a calc macro.
+   * @param macroAttributes the macro attributes possibly holding the sign-based role names.
+   *
+   * @return a single-entry {@code {"role": <name>}} map, or an empty map when no role applies.
+   */
+  public static Map<String, Object> signRoleAttributes(String result,
+                                                       Map<String, Object> macroAttributes) {
+    int signum;
+    try {
+      signum = new BigDecimal(result).signum();
+    } catch (NullPointerException | NumberFormatException e) {
+      return Collections.emptyMap();
+    }
+
+    String roleKey = signum > 0 ? Macro.Key.ROLE_POSITIVE
+                                : signum < 0 ? Macro.Key.ROLE_NEGATIVE
+                                             : Macro.Key.ROLE_ZERO;
+
+    Object role = macroAttributes.get(roleKey);
+    if (role == null) {
+      return Collections.emptyMap();
+    }
+    String roleName = String.valueOf(role).trim();
+
+    return roleName.isEmpty() ? Collections.emptyMap() : Map.of("role", roleName);
+  }
 
   public static RoundingMode roundingMode(org.asciidoctor.extension.BaseProcessor callingProcessor,
                                           Map<String, Object> attributes) {

--- a/src/main/java/com/lealceldeiro/asciidoc/extensions/calc/CalcMacro.java
+++ b/src/main/java/com/lealceldeiro/asciidoc/extensions/calc/CalcMacro.java
@@ -10,7 +10,6 @@ import com.lealceldeiro.asciidoc.extensions.calclogger.ExtensionLoggerFactory;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -40,7 +39,8 @@ public class CalcMacro extends InlineMacroProcessor implements Calc<Map<String, 
 
     // https://docs.asciidoctor.org/pdf-converter/latest/extend/create-converter/#override-a-method
     // https://www.rubydoc.info/gems/asciidoctor-pdf/Asciidoctor/PDF/Converter#convert_inline_quoted-instance_method
-    return createPhraseNode(parent, "quoted", calcResult, Collections.emptyMap());
+    return createPhraseNode(parent, "quoted", calcResult,
+                            Util.signRoleAttributes(calcResult, attributes));
   }
 
   @Override
@@ -91,6 +91,15 @@ public class CalcMacro extends InlineMacroProcessor implements Calc<Map<String, 
       configAttributeCount++;
     }
     if (attributes.containsKey(Macro.Key.ROUNDING_MODE)) {
+      configAttributeCount++;
+    }
+    if (attributes.containsKey(Macro.Key.ROLE_POSITIVE)) {
+      configAttributeCount++;
+    }
+    if (attributes.containsKey(Macro.Key.ROLE_NEGATIVE)) {
+      configAttributeCount++;
+    }
+    if (attributes.containsKey(Macro.Key.ROLE_ZERO)) {
       configAttributeCount++;
     }
     return configAttributeCount;

--- a/src/main/java/com/lealceldeiro/asciidoc/extensions/calcexpression/CalcExpressionMacro.java
+++ b/src/main/java/com/lealceldeiro/asciidoc/extensions/calcexpression/CalcExpressionMacro.java
@@ -11,7 +11,6 @@ import com.lealceldeiro.asciidoc.extensions.calclogger.ExtensionLogger;
 import com.lealceldeiro.asciidoc.extensions.calclogger.ExtensionLoggerFactory;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -76,7 +75,7 @@ public class CalcExpressionMacro extends InlineMacroProcessor implements Calc<Ca
 
     // https://docs.asciidoctor.org/pdf-converter/latest/extend/create-converter/#override-a-method
     // https://www.rubydoc.info/gems/asciidoctor-pdf/Asciidoctor/PDF/Converter#convert_inline_quoted-instance_method
-    return createPhraseNode(parent, "quoted", result, Collections.emptyMap());
+    return createPhraseNode(parent, "quoted", result, Util.signRoleAttributes(result, attributes));
   }
 
   static Attributes getCalculationAttributes(Document parentDocument,

--- a/src/test/java/com/lealceldeiro/asciidoc/extensions/UtilTest.java
+++ b/src/test/java/com/lealceldeiro/asciidoc/extensions/UtilTest.java
@@ -1,0 +1,65 @@
+package com.lealceldeiro.asciidoc.extensions;
+
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class UtilTest {
+  private static Map<String, Object> roles() {
+    return Map.of(Macro.Key.ROLE_POSITIVE, "success-bg",
+                  Macro.Key.ROLE_NEGATIVE, "danger-bg",
+                  Macro.Key.ROLE_ZERO, "neutral-bg");
+  }
+
+  @Test
+  void signRoleAttributesReturnsPositiveRoleForPositiveResult() {
+    Assertions.assertEquals(Map.of("role", "success-bg"),
+                            Util.signRoleAttributes("12.00", roles()));
+  }
+
+  @Test
+  void signRoleAttributesReturnsNegativeRoleForNegativeResult() {
+    Assertions.assertEquals(Map.of("role", "danger-bg"),
+                            Util.signRoleAttributes("-0.01", roles()));
+  }
+
+  @Test
+  void signRoleAttributesReturnsZeroRoleForZeroResult() {
+    Assertions.assertEquals(Map.of("role", "neutral-bg"),
+                            Util.signRoleAttributes("0.00", roles()));
+  }
+
+  @Test
+  void signRoleAttributesReturnsEmptyWhenMatchingRoleAbsent() {
+    // zero result but no role_zero provided -> no role
+    Map<String, Object> onlyNonZero = Map.of(Macro.Key.ROLE_POSITIVE, "success-bg",
+                                             Macro.Key.ROLE_NEGATIVE, "danger-bg");
+    Assertions.assertEquals(Collections.emptyMap(),
+                            Util.signRoleAttributes("0.00", onlyNonZero));
+  }
+
+  @Test
+  void signRoleAttributesReturnsEmptyWhenNoRolesProvided() {
+    Assertions.assertEquals(Collections.emptyMap(),
+                            Util.signRoleAttributes("12.00", Collections.emptyMap()));
+  }
+
+  @Test
+  void signRoleAttributesReturnsEmptyForBlankRoleValue() {
+    Assertions.assertEquals(Collections.emptyMap(),
+                            Util.signRoleAttributes("12.00", Map.of(Macro.Key.ROLE_POSITIVE, "  ")));
+  }
+
+  @Test
+  void signRoleAttributesReturnsEmptyForNonNumericResult() {
+    Assertions.assertEquals(Collections.emptyMap(),
+                            Util.signRoleAttributes(InvalidValue.NOT_A_NUMBER, roles()));
+  }
+
+  @Test
+  void signRoleAttributesReturnsEmptyForNullResult() {
+    Assertions.assertEquals(Collections.emptyMap(),
+                            Util.signRoleAttributes(null, roles()));
+  }
+}

--- a/src/test/java/com/lealceldeiro/asciidoc/extensions/calc/CalcMacroIntegrationTest.java
+++ b/src/test/java/com/lealceldeiro/asciidoc/extensions/calc/CalcMacroIntegrationTest.java
@@ -1,0 +1,41 @@
+package com.lealceldeiro.asciidoc.extensions.calc;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
+import org.asciidoctor.SafeMode;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class CalcMacroIntegrationTest {
+  private static String convert(String macro) {
+    String doc = String.join("\n", "", macro, "");
+    try (Asciidoctor asciidoctor = Asciidoctor.Factory.create()) {
+      return asciidoctor.convert(doc,
+          Options.builder().safe(SafeMode.UNSAFE).toFile(false).build());
+    }
+  }
+
+  @Test
+  void positiveSumRendersPositiveRole() {
+    String html = convert("calc:sum[100, 50, role_positive=success-bg, role_negative=danger-bg]");
+    Assertions.assertTrue(html.contains("150.00"), html);
+    Assertions.assertTrue(html.contains("success-bg"), html);
+    Assertions.assertFalse(html.contains("danger-bg"), html);
+  }
+
+  @Test
+  void negativeSubtractionRendersNegativeRole() {
+    String html = convert("calc:sub[50, 100, role_positive=success-bg, role_negative=danger-bg]");
+    Assertions.assertTrue(html.contains("-50.00"), html);
+    Assertions.assertTrue(html.contains("danger-bg"), html);
+    Assertions.assertFalse(html.contains("success-bg"), html);
+  }
+
+  @Test
+  void noRoleAttributesRendersNoRoleAndStillSums() {
+    String html = convert("calc:sum[100, 50]");
+    Assertions.assertTrue(html.contains("150.00"), html);
+    Assertions.assertFalse(html.contains("success-bg"), html);
+    Assertions.assertFalse(html.contains("danger-bg"), html);
+  }
+}

--- a/src/test/java/com/lealceldeiro/asciidoc/extensions/calcexpression/CalcExpressionMacroIntegrationTest.java
+++ b/src/test/java/com/lealceldeiro/asciidoc/extensions/calcexpression/CalcExpressionMacroIntegrationTest.java
@@ -1,0 +1,54 @@
+package com.lealceldeiro.asciidoc.extensions.calcexpression;
+
+import org.asciidoctor.Asciidoctor;
+import org.asciidoctor.Options;
+import org.asciidoctor.SafeMode;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class CalcExpressionMacroIntegrationTest {
+  private static String convert(String expression) {
+    String doc = String.join("\n",
+        ":author: Tester Person",
+        ":calc_exp_license_type: non_commercial",
+        "",
+        "calc_exp:[" + expression + "]",
+        "");
+    try (Asciidoctor asciidoctor = Asciidoctor.Factory.create()) {
+      return asciidoctor.convert(doc,
+          Options.builder().safe(SafeMode.UNSAFE).toFile(false).build());
+    }
+  }
+
+  @Test
+  void positiveResultRendersPositiveRole() {
+    String html = convert("100 - 50, role_positive=success-bg, role_negative=danger-bg");
+    Assertions.assertTrue(html.contains("50.00"), html);
+    Assertions.assertTrue(html.contains("success-bg"), html);
+    Assertions.assertFalse(html.contains("danger-bg"), html);
+  }
+
+  @Test
+  void negativeResultRendersNegativeRole() {
+    String html = convert("100 - 200, role_positive=success-bg, role_negative=danger-bg");
+    Assertions.assertTrue(html.contains("-100.00"), html);
+    Assertions.assertTrue(html.contains("danger-bg"), html);
+    Assertions.assertFalse(html.contains("success-bg"), html);
+  }
+
+  @Test
+  void zeroResultRendersNoRoleWhenZeroRoleOmitted() {
+    String html = convert("50 - 50, role_positive=success-bg, role_negative=danger-bg");
+    Assertions.assertTrue(html.contains("0.00"), html);
+    Assertions.assertFalse(html.contains("success-bg"), html);
+    Assertions.assertFalse(html.contains("danger-bg"), html);
+  }
+
+  @Test
+  void noRoleAttributesRendersNoRole() {
+    String html = convert("100 - 50");
+    Assertions.assertTrue(html.contains("50.00"), html);
+    Assertions.assertFalse(html.contains("success-bg"), html);
+    Assertions.assertFalse(html.contains("danger-bg"), html);
+  }
+}


### PR DESCRIPTION
## What

Adds optional, **role-agnostic** sign-to-role styling to the `calc` and `calc_exp` inline macros. The rendered result is wrapped with a role chosen by its sign, using role names the author supplies:

| Sign | Attribute |
|------|-----------|
| `> 0` | `role_positive` |
| `< 0` | `role_negative` |
| `= 0` | `role_zero` |

```adoc
calc_exp:[{income} - {expenses}, role_positive=success-bg, role_negative=danger-bg]
calc:sum[{a}, {b}, role_positive=success-bg, role_negative=danger-bg]
```

The macros never hardcode concrete role names — they only stamp whatever string the author passes onto the output node's `role`. When the relevant attribute is absent/blank, or the result is not a number, **no role is applied**, so all existing usages are unchanged.

## How

- New keys `role_positive` / `role_negative` / `role_zero` in `Macro.Key`.
- New shared helper `Util.signRoleAttributes(result, macroAttributes)` returns `{"role": <name>}` or an empty map; both macros pass it to `createPhraseNode` instead of `Collections.emptyMap()`.
- `CalcMacro.positionalAttributesCount` counts the new named attributes as config, so `calc:sum[..., role_*]` is not miscounted as operands (would otherwise return `NaN`).

## Testing

- `UtilTest` (8): positive/negative/zero, missing/blank role, non-numeric, null.
- `CalcExpressionMacroIntegrationTest` (4) and `CalcMacroIntegrationTest` (3): `Asciidoctor.convert` asserting the role reaches rendered HTML by sign, and no role when omitted.
- Full suite: **335 passing**.

## Notes

- Backward compatible: no behavior change when the role attributes are omitted.
- `pom.xml` bumped `2.4.0 → 2.4.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)