### PR TITLE
chore: add Claude Code project resources

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,21 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./mvnw:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git fetch:*)",
+      "Bash(git add:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh issue view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run list:*)"
+    ]
+  }
+}

--- a/.claude/skills/add-macro/SKILL.md
+++ b/.claude/skills/add-macro/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: add-macro
+description: Use when adding a new Asciidoctor macro (inline or block) to this extension library. Covers the processor + registry + dual SPI registration and the test/README conventions, so the macro actually loads and is verified end-to-end.
+---
+
+# Adding a new macro to asciidoc-extensions
+
+A macro is a **triplet** — processor + registry + SPI registration — and it is not done
+until it is registered in **both** SPI files, tested with a real render, and documented.
+Work through the checklist in order.
+
+## Checklist
+
+1. **Processor class** — `src/main/java/com/lealceldeiro/asciidoc/extensions/<name>/<Name>Macro.java`.
+   - Inline macro → extend `org.asciidoctor.extension.InlineMacroProcessor` and annotate
+     with `@Name("<macro_name>")` (and `@PositionalAttributes(...)` if it takes positional
+     args). A block macro (like `chart`) extends `BlockProcessor` instead.
+   - Put **pure, unit-testable logic** in a `calculate(...)`-style method (or a helper
+     class) so it can be tested without the Asciidoctor runtime. `process(...)` should just
+     wire inputs, call that logic, and build the phrase/block node.
+   - Reuse the shared building blocks rather than re-inventing them: attribute names go in
+     `Macro.Key`, sentinel results in `InvalidValue`, rounding/sign→role helpers in `Util`,
+     operators in `Operator`. Return an `InvalidValue` sentinel for bad input — **do not
+     throw**.
+
+2. **Registry class** — `src/main/java/com/lealceldeiro/asciidoc/extensions/<Name>MacroExtensionRegistry.java`
+   implementing `org.asciidoctor.extension.spi.ExtensionRegistry`, registering the macro
+   (e.g. `javaExtensionRegistry.inlineMacro("<macro_name>", <Name>Macro.class)` or
+   `.block(...)` for a block macro). Model it on `CalcMacroExtensionRegistry`.
+
+3. **⚠️ Register in BOTH SPI files** — this is the step that is silently forgotten; a macro
+   that compiles and unit-tests fine will simply not load if either is missed. Add the fully
+   qualified registry class name to **both**:
+   - `src/main/resources/META-INF/services/org.asciidoctor.extension.spi.ExtensionRegistry`
+   - `src/main/resources/META-INF/services/org.asciidoctor.jruby.extension.spi.ExtensionRegistry`
+
+4. **Unit test** the pure logic — `src/test/java/.../<name>/<Name>MacroTest.java`, asserting
+   on `calculate(...)` output including the relevant `InvalidValue` sentinels.
+
+5. **Integration test** the real render — `<Name>MacroIntegrationTest.java` that calls
+   `Asciidoctor.convert(doc, Options.builder().safe(SafeMode.UNSAFE).toFile(false).build())`
+   and asserts on the produced HTML. This is what actually proves the SPI registration
+   works. Model it on `ChartMacroIntegrationTest` / `CalcMacroIntegrationTest`. Note that
+   surefire runs `*IntegrationTest` classes in the normal `test` phase.
+
+6. **Run the suite:** `./mvnw test` (all green — no `-Dgpg.skip` needed for `test`).
+
+7. **Document it in `README.md`** — add a `## \`<macro_name>\`` section following the
+   existing macros' structure (usage examples, attributes, invalid-value behavior), and
+   note the version it was introduced in.
+
+## Notes
+
+- If the macro evaluates user-supplied math via mXparser (like `calc_exp`), it also needs
+  the document `author` (≥ 5 chars) and `calc_exp_license_type` attributes, or it returns
+  `NaA` / `NaVA` / `NaL`. See `README.md` and `CLAUDE.md`.
+- Adding a macro is a functional change → it warrants a version bump and release (see
+  `CONTRIBUTING.md`), unlike config-only changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repository is
+
+A small Java library of **Asciidoctor extensions**, published to Maven Central as
+`com.lealceldeiro:asciidoc-extensions`. It provides custom macros used when rendering
+AsciiDoc (to PDF/HTML):
+
+- `calc` — simple arithmetic: `calc:sum[...]`, `sub`, `multiply`, `divide`
+- `calc_exp` — evaluates a math expression (backed by mXparser)
+- `calc_date` — date arithmetic / formatting
+- `chart` — a line-chart **block** macro that renders an inline SVG
+
+Full macro usage and attributes are documented in `README.md`; the release process is in
+`CONTRIBUTING.md`. Prefer linking to those files over duplicating them here.
+
+## Build & test
+
+Java 25 (`zulu`) + Maven 3.9.9 — see `.sdkmanrc` (`sdk env`). Use the wrapper `./mvnw`.
+
+```shell
+./mvnw test                     # unit + integration tests (surefire runs *Test AND *IntegrationTest)
+./mvnw -Dgpg.skip=true install  # build & install to the local ~/.m2 repo
+```
+
+**GPG gotcha:** the `maven-gpg-plugin` `sign` goal is bound to the **`verify`** phase, so
+`test` and `package` are clean locally, but `verify` / `install` / `deploy` try to sign and
+fail without the signing key — pass `-Dgpg.skip=true` for local runs. CI imports the key
+from secrets, so never bake `-Dgpg.skip` into the build itself.
+
+No checkstyle/formatter plugin runs: style is governed by `.editorconfig` (2-space indent)
+and analyzed by SonarCloud. Keep imports clean (no unused imports).
+
+## Architecture: the macro pattern
+
+Each macro is a **triplet**, and adding one touches all three parts plus tests:
+
+1. A processor class (e.g. `calc/CalcMacro.java`) extending `InlineMacroProcessor`
+   (or `BlockProcessor`, as `chart` does).
+2. An `*ExtensionRegistry` class (e.g. `CalcMacroExtensionRegistry.java`) that registers
+   the macro name with the AsciidoctorJ registry.
+3. **Both** SPI service files under `src/main/resources/META-INF/services/` —
+   `org.asciidoctor.extension.spi.ExtensionRegistry` **and**
+   `org.asciidoctor.jruby.extension.spi.ExtensionRegistry` — must list the registry class.
+   Missing either file means the macro silently fails to load. This is the easiest step to
+   forget; the `/add-macro` skill walks the full checklist.
+
+Shared building blocks (package root `com.lealceldeiro.asciidoc.extensions`): `Macro.Key` /
+`Macro.Value` (attribute names), `Operator`, `Util` (rounding + sign→role helpers),
+`InvalidValue` (sentinel results), `Calc` (interface), `calclogger/` (logging).
+
+## Conventions & gotchas
+
+- **Macros return sentinel strings; they do not throw.** Invalid input yields an
+  `InvalidValue` code — `NaN` (bad number), `NaO` (bad operation), `NaE` (bad expression),
+  `NaL` (bad license), `NaA` / `NaVA` (missing / too-short author), `NaVM` (invalid math),
+  `NaD` / `NaF` (bad date / format). Tests assert on these strings.
+- **`calc_exp` needs a license.** mXparser requires license confirmation, so `calc_exp`
+  returns `NaA` / `NaVA` without a valid document `author` (≥ 5 chars) and `NaL` without
+  `calc_exp_license_type` (`commercial` | `non_commercial`).
+- **Results are `BigDecimal` at scale 2**, rounded `HALF_EVEN` by default (override via the
+  `rounding_mode` attribute).
+- **Testing convention:** pure logic is unit-tested against `calculate(...)`; end-to-end
+  rendering is covered by `*IntegrationTest` classes that call `Asciidoctor.convert(...)`
+  and assert on the produced HTML.
+
+## Releasing
+
+See `CONTRIBUTING.md`. In short: bump `<version>` on a chore branch → PR → merge → tag
+`release/x.y.z` on `main` → `git push --tags` (the `maven-publish` workflow deploys to
+Central). Config-only changes with no functional impact don't need a version bump/release.


### PR DESCRIPTION
Initializes Claude Code support for the repository so future sessions launched from this repo start with the right context and fewer permission prompts. **No functional change; project version stays `2.4.1` (no release needed).**

## What's added

### `CLAUDE.md`
Orientation layer + the non-obvious gotchas a fresh session would otherwise get wrong, linking out to `README.md` / `CONTRIBUTING.md` instead of duplicating them:
- GPG `sign` is bound to the **`verify`** phase → `test`/`package` are clean locally, but `verify`/`install`/`deploy` need `-Dgpg.skip=true` (CI imports the key).
- The macro **triplet** (`*Macro` + `*ExtensionRegistry` + SPI) and the **dual** `META-INF/services` registration requirement.
- `InvalidValue` sentinels are returned, not thrown; the `calc_exp` mXparser license requirement (`author` ≥ 5 chars + `calc_exp_license_type`).
- Java 25 / Maven 3.9.9 via `.sdkmanrc`; `*Test` + `*IntegrationTest` convention.

### `.claude/settings.json`
A conservative permissions allowlist for `./mvnw` and read-only `git` / `gh` commands (no destructive or outward-facing commands allowlisted).

### `.claude/skills/add-macro/SKILL.md`
A `/add-macro` checklist for adding a new macro, front-loading the easily-missed step of registering the new registry in **both** SPI service files.

## Notes
- `.claude/` is not gitignored; `settings.json` validated as parseable JSON.
- Scope deliberately kept small (no hooks/subagents/MCP) for a ~20-file library; easy to extend later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)